### PR TITLE
Add missing includes

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -32,9 +32,9 @@ download assimp, GLM, GLFW, stb and tinyfiledialogs if they are not found on
 your computer, so you only need to make sure that CMake and Git are installed
 on your computer.
 
-An OpenGL 4.1 context is created by the project; if your hardware or its driver
-does not support OpenGL 4.1, you should use the `OpenGL 3.3`_ branch instead
-which will create a 3.3 context.
+An OpenGL 3.3 context is created by the project; note that this branch is meant
+for older GPUs or drivers which do not support the OpenGL 4.1 context created
+when using the master_ branch, and should only be used in those scenarios.
 
 C++14 features are used by this project, so you will need a C++14-capable
 compiler; if you are using Visual Studio, that means Visual Studio 2015 or
@@ -139,6 +139,7 @@ Licence
 .. _assimp: https://github.com/assimp/assimp
 .. _stb: https://github.com/nothings/stb
 .. _tinyfiledialogs: https://sourceforge.net/projects/tinyfiledialogs/
+.. _master: https://github.com/LUGGPublic/CG_Labs/tree/master
 .. _cmake-generators(7): https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html
 .. _Dear ImGui’s licence: src/external/Dear ImGui/LICENSE.txt
 .. _OpenGL 3.3: https://github.com/LUGGPublic/CG_Labs/tree/OpenGL_3.3

--- a/shaders/EDAF80/binormal.frag
+++ b/shaders/EDAF80/binormal.frag
@@ -1,4 +1,4 @@
-#version 410
+#version 330
 
 in VS_OUT {
 	vec3 binormal;

--- a/shaders/EDAF80/binormal.vert
+++ b/shaders/EDAF80/binormal.vert
@@ -1,4 +1,4 @@
-#version 410
+#version 330
 
 layout (location = 0) in vec3 vertex;
 layout (location = 4) in vec3 binormal;

--- a/shaders/EDAF80/celestial_ring.frag
+++ b/shaders/EDAF80/celestial_ring.frag
@@ -1,4 +1,4 @@
-#version 410
+#version 330
 
 uniform sampler2D diffuse_texture;
 uniform int has_diffuse_texture;

--- a/shaders/EDAF80/celestial_ring.vert
+++ b/shaders/EDAF80/celestial_ring.vert
@@ -1,4 +1,4 @@
-#version 410
+#version 330
 
 layout (location = 0) in vec3 vertex;
 layout (location = 2) in vec3 texcoord;

--- a/shaders/EDAF80/default.frag
+++ b/shaders/EDAF80/default.frag
@@ -1,4 +1,4 @@
-#version 410
+#version 330
 
 uniform sampler2D diffuse_texture;
 uniform int has_diffuse_texture;

--- a/shaders/EDAF80/default.vert
+++ b/shaders/EDAF80/default.vert
@@ -1,4 +1,4 @@
-#version 410
+#version 330
 
 layout (location = 0) in vec3 vertex;
 layout (location = 2) in vec3 texcoord;

--- a/shaders/EDAF80/diffuse.frag
+++ b/shaders/EDAF80/diffuse.frag
@@ -1,4 +1,4 @@
-#version 410
+#version 330
 
 uniform vec3 light_position;
 

--- a/shaders/EDAF80/diffuse.vert
+++ b/shaders/EDAF80/diffuse.vert
@@ -1,4 +1,4 @@
-#version 410
+#version 330
 
 // Remember how we enabled vertex attributes in assignment 2 and attached some
 // data to each of them, here we retrieve that data. Attribute 0 pointed to the

--- a/shaders/EDAF80/fallback.frag
+++ b/shaders/EDAF80/fallback.frag
@@ -1,4 +1,4 @@
-#version 410
+#version 330
 
 out vec4 frag_color;
 

--- a/shaders/EDAF80/fallback.vert
+++ b/shaders/EDAF80/fallback.vert
@@ -1,4 +1,4 @@
-#version 410
+#version 330
 
 layout (location = 0) in vec3 vertex;
 

--- a/shaders/EDAF80/fullscreen.frag
+++ b/shaders/EDAF80/fullscreen.frag
@@ -1,4 +1,4 @@
-#version 410
+#version 330
 
 in VS_OUT {
 	vec2 texcoord;

--- a/shaders/EDAF80/fullscreen.vert
+++ b/shaders/EDAF80/fullscreen.vert
@@ -1,4 +1,4 @@
-#version 410
+#version 330
 
 // Trick from
 // https://rauwendaal.net/2014/06/14/rendering-a-screen-covering-triangle-in-opengl/

--- a/shaders/EDAF80/normal.frag
+++ b/shaders/EDAF80/normal.frag
@@ -1,4 +1,4 @@
-#version 410
+#version 330
 
 in VS_OUT {
 	vec3 normal;

--- a/shaders/EDAF80/normal.vert
+++ b/shaders/EDAF80/normal.vert
@@ -1,4 +1,4 @@
-#version 410
+#version 330
 
 layout (location = 0) in vec3 vertex;
 layout (location = 1) in vec3 normal;

--- a/shaders/EDAF80/tangent.frag
+++ b/shaders/EDAF80/tangent.frag
@@ -1,4 +1,4 @@
-#version 410
+#version 330
 
 in VS_OUT {
 	vec3 tangent;

--- a/shaders/EDAF80/tangent.vert
+++ b/shaders/EDAF80/tangent.vert
@@ -1,4 +1,4 @@
-#version 410
+#version 330
 
 layout (location = 0) in vec3 vertex;
 layout (location = 3) in vec3 tangent;

--- a/shaders/EDAF80/texcoord.frag
+++ b/shaders/EDAF80/texcoord.frag
@@ -1,4 +1,4 @@
-#version 410
+#version 330
 
 in VS_OUT {
 	vec2 texcoord;

--- a/shaders/EDAF80/texcoord.vert
+++ b/shaders/EDAF80/texcoord.vert
@@ -1,4 +1,4 @@
-#version 410
+#version 330
 
 layout (location = 0) in vec3 vertex;
 layout (location = 2) in vec3 texcoord;

--- a/shaders/EDAN35/accumulate_lights.frag
+++ b/shaders/EDAN35/accumulate_lights.frag
@@ -1,4 +1,4 @@
-#version 410
+#version 330
 
 uniform sampler2D depth_texture;
 uniform sampler2D normal_texture;

--- a/shaders/EDAN35/accumulate_lights.vert
+++ b/shaders/EDAN35/accumulate_lights.vert
@@ -1,4 +1,4 @@
-#version 410
+#version 330
 
 uniform mat4 vertex_model_to_world;
 uniform mat4 vertex_world_to_clip;

--- a/shaders/EDAN35/fill_gbuffer.frag
+++ b/shaders/EDAN35/fill_gbuffer.frag
@@ -1,4 +1,4 @@
-#version 410
+#version 330
 
 uniform bool has_diffuse_texture;
 uniform bool has_specular_texture;

--- a/shaders/EDAN35/fill_gbuffer.vert
+++ b/shaders/EDAN35/fill_gbuffer.vert
@@ -1,4 +1,4 @@
-#version 410
+#version 330
 
 uniform mat4 vertex_model_to_world;
 uniform mat4 vertex_world_to_clip;

--- a/shaders/EDAN35/fill_shadowmap.frag
+++ b/shaders/EDAN35/fill_shadowmap.frag
@@ -1,4 +1,4 @@
-#version 410
+#version 330
 
 void main()
 {

--- a/shaders/EDAN35/fill_shadowmap.vert
+++ b/shaders/EDAN35/fill_shadowmap.vert
@@ -1,4 +1,4 @@
-#version 410
+#version 330
 
 uniform mat4 vertex_model_to_world;
 uniform mat4 vertex_world_to_clip;

--- a/shaders/EDAN35/render_light_cones.frag
+++ b/shaders/EDAN35/render_light_cones.frag
@@ -1,4 +1,4 @@
-#version 410
+#version 330
 
 out vec3 frag_color;
 

--- a/shaders/EDAN35/render_light_cones.vert
+++ b/shaders/EDAN35/render_light_cones.vert
@@ -1,4 +1,4 @@
-#version 410
+#version 330
 
 uniform mat4 vertex_model_to_world;
 uniform mat4 vertex_world_to_clip;

--- a/shaders/EDAN35/resolve_deferred.frag
+++ b/shaders/EDAN35/resolve_deferred.frag
@@ -1,4 +1,4 @@
-#version 410
+#version 330
 
 uniform sampler2D diffuse_texture;
 uniform sampler2D specular_texture;

--- a/shaders/EDAN35/resolve_deferred.vert
+++ b/shaders/EDAN35/resolve_deferred.vert
@@ -1,4 +1,4 @@
-#version 410
+#version 330
 
 // Trick from
 // https://rauwendaal.net/2014/06/14/rendering-a-screen-covering-triangle-in-opengl/

--- a/shaders/fallback.frag
+++ b/shaders/fallback.frag
@@ -1,4 +1,4 @@
-#version 410
+#version 330
 
 out vec4 frag_color;
 

--- a/shaders/fallback.vert
+++ b/shaders/fallback.vert
@@ -1,4 +1,4 @@
-#version 410
+#version 330
 
 layout (location = 0) in vec3 vertex;
 

--- a/src/EDAF80/assignment1.cpp
+++ b/src/EDAF80/assignment1.cpp
@@ -159,7 +159,7 @@ int main()
 	sun.add_texture("diffuse_texture", sun_texture, GL_TEXTURE_2D);
 
 
-	glClearDepthf(1.0f);
+	glClearDepth(1.0);
 	glClearColor(0.1f, 0.1f, 0.1f, 1.0f);
 	glEnable(GL_DEPTH_TEST);
 

--- a/src/EDAF80/assignment2.cpp
+++ b/src/EDAF80/assignment2.cpp
@@ -122,7 +122,7 @@ edaf80::Assignment2::run()
 	//! \todo Create a tesselated sphere and a tesselated torus
 
 
-	glClearDepthf(1.0f);
+	glClearDepth(1.0);
 	glClearColor(0.1f, 0.1f, 0.1f, 1.0f);
 	glEnable(GL_DEPTH_TEST);
 

--- a/src/EDAF80/assignment3.cpp
+++ b/src/EDAF80/assignment3.cpp
@@ -121,7 +121,7 @@ edaf80::Assignment3::run()
 	demo_sphere.set_program(&fallback_shader, set_uniforms);
 
 
-	glClearDepthf(1.0f);
+	glClearDepth(1.0);
 	glClearColor(0.1f, 0.1f, 0.1f, 1.0f);
 	glEnable(GL_DEPTH_TEST);
 

--- a/src/EDAF80/assignment4.cpp
+++ b/src/EDAF80/assignment4.cpp
@@ -60,7 +60,7 @@ edaf80::Assignment4::run()
 	// Todo: Load your geometry
 	//
 
-	glClearDepthf(1.0f);
+	glClearDepth(1.0);
 	glClearColor(0.1f, 0.1f, 0.1f, 1.0f);
 	glEnable(GL_DEPTH_TEST);
 

--- a/src/EDAF80/assignment5.cpp
+++ b/src/EDAF80/assignment5.cpp
@@ -54,7 +54,7 @@ edaf80::Assignment5::run()
 	// Todo: Load your geometry
 	//
 
-	glClearDepthf(1.0f);
+	glClearDepth(1.0);
 	glClearColor(0.1f, 0.1f, 0.1f, 1.0f);
 	glEnable(GL_DEPTH_TEST);
 

--- a/src/EDAN35/assignment2.cpp
+++ b/src/EDAN35/assignment2.cpp
@@ -246,7 +246,7 @@ edan35::Assignment2::run()
 
 
 	glClearColor(0.0f, 0.0f, 0.0f, 1.0f);
-	glClearDepthf(1.0f);
+	glClearDepth(1.0);
 	glEnable(GL_DEPTH_TEST);
 	glEnable(GL_CULL_FACE);
 

--- a/src/core/WindowManager.cpp
+++ b/src/core/WindowManager.cpp
@@ -10,8 +10,8 @@
 
 namespace
 {
-	const int default_opengl_major_version = 4;
-	const int default_opengl_minor_version = 1;
+	const int default_opengl_major_version = 3;
+	const int default_opengl_minor_version = 3;
 	const int default_glsl_version = default_opengl_major_version * 100 + default_opengl_minor_version * 10;
 
 	void ErrorCallback(int error, char const* description)

--- a/src/core/WindowManager.cpp
+++ b/src/core/WindowManager.cpp
@@ -17,7 +17,7 @@ namespace
 	void ErrorCallback(int error, char const* description)
 	{
 		if (error == 65543 || error == 65545)
-			LogError("Couldn't create an OpenGL %d.%d context.\nIf you are using old hardware/drivers which support OpenGL 3.3 but not higher, try using the 'OpenGL_3.3' branch.", default_opengl_major_version, default_opengl_minor_version);
+			LogError("Couldn't create an OpenGL %d.%d context.\nEnsure you are using hardware/drivers which support at least OpenGL 3.3.", default_opengl_major_version, default_opengl_minor_version);
 		else
 			LogError("GLFW error %d was thrown:\n\t%s\n", error, description);
 	}

--- a/src/core/WindowManager.hpp
+++ b/src/core/WindowManager.hpp
@@ -8,6 +8,7 @@
 
 #include <mutex>
 #include <unordered_map>
+#include <memory>
 
 //! \brief A simple class for creating and interacting with windows, using the
 //!        GLFW library.

--- a/src/core/helpers.cpp
+++ b/src/core/helpers.cpp
@@ -15,6 +15,7 @@
 #include <array>
 #include <cassert>
 #include <cstdint>
+#include <memory>
 
 namespace local
 {

--- a/src/core/node.cpp
+++ b/src/core/node.cpp
@@ -119,7 +119,7 @@ Node::add_texture(std::string const& name, GLuint tex_id, GLenum type)
 	glGetIntegerv(GL_MAX_COMBINED_TEXTURE_IMAGE_UNITS, &max_combined_texture_image_units);
 	std::size_t const max_active_texture_count
 		= (max_combined_texture_image_units > 0) ? static_cast<std::size_t>(max_combined_texture_image_units)
-		                                         : 80; // OpenGL 4.x guarantees at least 80.
+		                                         : 48; // OpenGL 3.x guarantees at least 48.
 
 	if (_textures.size() >= max_active_texture_count) {
 		LogWarning("Trying to add more textures to an object than supported (%llu); the texture %s with ID %u will **not** be added. If you really need that many textures, do not use the `Node` class and roll your own solution instead.",


### PR DESCRIPTION
The code didn't compile with gcc-12.
Likely they were included as part of other parts of the standard library,
causing the code to break after some internal restructuring of gcc.
