### PR TITLE
Make the basis vector shaders compile

### DIFF
--- a/shaders/common/basis.frag
+++ b/shaders/common/basis.frag
@@ -1,7 +1,7 @@
 #version 330
 
 in VS_OUT {
-	flat uint axis_index;
+	flat int axis_index;
 } vs_out;
 
 out vec4 frag_color;

--- a/shaders/common/basis.vert
+++ b/shaders/common/basis.vert
@@ -8,7 +8,7 @@ uniform float thickness_scale;
 uniform float length_scale;
 
 out VS_OUT {
-	flat uint axis_index;
+	flat int axis_index;
 } vs_out;
 
 


### PR DESCRIPTION
Showing the basis vectors resulted in errors,
causing the shaders to not compile.
This makes it impossible to view the base axes.

The errors were caused by axis\_index being of type uint,
while being assigned and compared to ints.
Changing the type of axis\_index solves this problem, which also makes the
axes possible to view.