### PR TITLE
Add ignores for Linux CMake systems

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,12 @@
+#
+# Course-specific
+#
+
+# Compiled executives specific to courses involved
+# as they don't have extensions by default in Linux
+EDAF80_Assignment*
+EDAN35_Assignment*
+
 # Build folders
 build/
 Debug/
@@ -22,3 +31,56 @@ log.txt
 *.sdf
 *.suo
 *.vcxproj.user
+
+#
+# C/C++
+# from: https://github.com/github/gitignore/blob/main/C%2B%2B.gitignore
+#
+# Prerequisites
+*.d
+
+# Compiled Object files
+*.slo
+*.lo
+*.o
+*.obj
+
+# Precompiled Headers
+*.gch
+*.pch
+
+# Compiled Dynamic libraries
+*.so
+*.dylib
+*.dll
+
+# Fortran module files
+*.mod
+*.smod
+
+# Compiled Static libraries
+*.lai
+*.la
+*.a
+*.lib
+
+# Executables
+*.exe
+*.out
+*.app
+
+#
+# CMake
+# from: https://github.com/github/gitignore/blob/main/CMake.gitignore
+#
+CMakeLists.txt.user
+CMakeCache.txt
+CMakeFiles
+CMakeScripts
+Testing
+Makefile
+cmake_install.cmake
+install_manifest.txt
+compile_commands.json
+CTestTestfile.cmake
+_deps


### PR DESCRIPTION
A PR intended to improve the quality of life for users with Linux systems and CMake + make. Since the CMake and make systems generate build maps and compiled objects that are not covered by the git-ignore file. In my case I just ran `cmake .` in the repository's root to get started on the assignments immediately.

The changes were adding two different git-ignore templates to the repo's git-ignore - from the public repository here: https://github.com/github/gitignore

Before:
![image](https://user-images.githubusercontent.com/13331724/191615790-2af90d3b-4065-4780-8c85-63b94524c33c.png)

After:
![image](https://user-images.githubusercontent.com/13331724/191615932-7eb8c6c0-3b0d-4dfb-9030-12a8272b206c.png)